### PR TITLE
Implement authorisation checks in MID API

### DIFF
--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthenticationInterceptor;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthorisationInterceptor;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.service.MissingImageDeliveryItemService;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
 
@@ -19,10 +22,14 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     @Value("${uk.gov.companieshouse.missingimagedelivery.orders.api.home}")
     private String MISSING_IMAGE_DELIVERY_HOME;
 
+    @Autowired
+    private MissingImageDeliveryItemService missingImageDeliveryItemService;
+
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new UserAuthenticationInterceptor()).addPathPatterns(MISSING_IMAGE_DELIVERY_HOME + "/**")
                 .excludePathPatterns(MISSING_IMAGE_DELIVERY_HOME + "/healthcheck");
+        registry.addInterceptor(new UserAuthorisationInterceptor(missingImageDeliveryItemService)).addPathPatterns(MISSING_IMAGE_DELIVERY_HOME + "/**");
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptor.java
@@ -1,0 +1,113 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
+
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.service.MissingImageDeliveryItemService;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.util.EricHeaderHelper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.IDENTITY_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.MISSING_IMAGE_DELIVERY_ID_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.REQUEST_ID_HEADER_NAME;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.REQUEST_ID_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.STATUS_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.USER_ID_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.getLogger;
+
+public class UserAuthorisationInterceptor extends HandlerInterceptorAdapter {
+
+    private final MissingImageDeliveryItemService service;
+
+    private static final Logger LOGGER = getLogger();
+
+    public UserAuthorisationInterceptor(MissingImageDeliveryItemService service) {
+        this.service = service;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        final String identityType = EricHeaderHelper.getIdentityType(request);
+        boolean isApiKeyRequest = identityType.equals(EricHeaderHelper.API_KEY_IDENTITY_TYPE);
+        boolean isOAuth2Request = identityType.equals(EricHeaderHelper.OAUTH2_IDENTITY_TYPE);
+
+        if(isApiKeyRequest) {
+            return validateAPI(request, response);
+        }
+        else if(isOAuth2Request) {
+            return validateOAuth2(request, response);
+        }
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put(REQUEST_ID_LOG_KEY, request.getHeader(REQUEST_ID_HEADER_NAME));
+        LOGGER.error("Unrecognised identity type", logMap);
+        response.setStatus(UNAUTHORIZED.value());
+        return false;
+    }
+
+    private boolean validateAPI(HttpServletRequest request, HttpServletResponse response){
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put(REQUEST_ID_LOG_KEY, request.getHeader(REQUEST_ID_HEADER_NAME));
+        if(GET.matches(request.getMethod())) {
+            LOGGER.info("API is permitted to view the resource", logMap);
+            return true;
+        } else {
+            logMap.put(STATUS_LOG_KEY, UNAUTHORIZED);
+            LOGGER.error("API is not permitted to perform a "+request.getMethod(), logMap);
+            response.setStatus(UNAUTHORIZED.value());
+            return false;
+        }
+    }
+
+    private boolean validateOAuth2(HttpServletRequest request, HttpServletResponse response) {
+        if (!POST.matches(request.getMethod())) {
+            final Map<String, String> pathVariables = (Map) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+            final String missingImageDeliveryId = pathVariables.get("id");
+
+            final String identity = EricHeaderHelper.getIdentity(request);
+            Optional<MissingImageDeliveryItem> item = service.getMissingImageDeliveryItemById(missingImageDeliveryId);
+
+            Map<String, Object> logMap = new HashMap<>();
+            logMap.put(MISSING_IMAGE_DELIVERY_ID_LOG_KEY, missingImageDeliveryId);
+            logMap.put(REQUEST_ID_LOG_KEY, request.getHeader(REQUEST_ID_HEADER_NAME));
+            logMap.put(IDENTITY_LOG_KEY, identity);
+
+            if (item.isPresent()) {
+                String userId = item.get().getUserId();
+                if (userId == null) {
+                    logMap.put(STATUS_LOG_KEY,UNAUTHORIZED);
+                    LOGGER.error("No user id found on missing-image-delivery item, all missing-image-delivery's should have a user id", logMap);
+                    response.setStatus(UNAUTHORIZED.value());
+                    return false;
+                }
+                logMap.put(USER_ID_LOG_KEY, userId);
+                boolean authUserIsCreatedBy = userId.equals(identity);
+                if (authUserIsCreatedBy) {
+                    LOGGER.info("User is permitted to view/edit the resource missing-image-delivery with userId", logMap);
+                    return true;
+                } else {
+                    logMap.put(STATUS_LOG_KEY,UNAUTHORIZED);
+                    LOGGER.error("User is not permitted to view/edit the resource missing-image-delivery with userId", logMap);
+                    response.setStatus(UNAUTHORIZED.value());
+                    return false;
+                }
+            } else {
+                logMap.put(STATUS_LOG_KEY,NOT_FOUND);
+                LOGGER.error("Resource missing-image-delivery item not found", logMap);
+                response.setStatus(NOT_FOUND.value());
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptorTest.java
@@ -1,4 +1,142 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.service.MissingImageDeliveryItemService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_IDENTITY_HEADER_NAME;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_IDENTITY_TYPE_API_KEY_VALUE;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_IDENTITY_TYPE_HEADER_NAME;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_IDENTITY_TYPE_OAUTH2_VALUE;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_IDENTITY_VALUE;
+
+@ExtendWith(MockitoExtension.class)
 public class UserAuthorisationInterceptorTest {
+
+    @InjectMocks
+    private UserAuthorisationInterceptor userAuthorisationInterceptor;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private MissingImageDeliveryItemService service;
+
+    private static final String ITEM_ID = "MID-642716-013908";
+    private static final String ALTERNATIVE_CREATED_BY = "xyz321";
+    private static final String INVALID_IDENTITY_TYPE_VALUE = "test";
+
+    @Test
+    @DisplayName("Authorise if authenticated user created the missing-image-delivery when request method is GET")
+    void willAuthoriseIfAuthorisedUserCreatedTheMissingImageDeliveryWhenRequestMethodIsGet() {
+        Map<String, String> map = new HashMap<>();
+        map.put("id", ITEM_ID);
+
+        MissingImageDeliveryItem item = new MissingImageDeliveryItem();
+        item.setId(ITEM_ID);
+        item.setUserId(ERIC_IDENTITY_VALUE);
+
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(map);
+        doReturn(ERIC_IDENTITY_VALUE).when(request).getHeader(ERIC_IDENTITY_HEADER_NAME);
+        doReturn(ERIC_IDENTITY_TYPE_OAUTH2_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME);
+        when(service.getMissingImageDeliveryItemById(ITEM_ID)).thenReturn(Optional.of(item));
+
+        assertTrue(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Authorise if request method is POST for a user")
+    void willAuthoriseIfPostAndOAuth2() {
+        when(request.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(request.getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME)).thenReturn(ERIC_IDENTITY_TYPE_OAUTH2_VALUE);
+
+        assertTrue(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not authorise if authenticated user did not create the missing-image-delivery when request method is GET")
+    void doesNotAuthoriseIfAuthenticatedUserDidNotCreateTheMissingImageDeliveryWhenRequestMethodGet() {
+        Map<String, String> map = new HashMap<>();
+        map.put("id", ITEM_ID);
+
+        MissingImageDeliveryItem item = new MissingImageDeliveryItem();
+        item.setId(ITEM_ID);
+        item.setUserId(ALTERNATIVE_CREATED_BY);
+
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(map);
+        doReturn(ERIC_IDENTITY_VALUE).when(request).getHeader(ERIC_IDENTITY_HEADER_NAME);
+        doReturn(ERIC_IDENTITY_TYPE_OAUTH2_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME);
+        when(service.getMissingImageDeliveryItemById(ITEM_ID)).thenReturn(Optional.of(item));
+
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not Authorise if request method is GET and there is no user")
+    public void willNotAuthoriseIfMethodIsGetAndNoIdentity() {
+        when(request.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(request.getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME)).thenReturn(ERIC_IDENTITY_TYPE_OAUTH2_VALUE);
+
+        assertTrue(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not authorise if missing-image-delivery is not found when request method is GET for a user")
+    public void willNotAuthoriseIfMissingImageDeliveryIsNotFoundAndOAuth2() {
+        Map<String, String> map = new HashMap<>();
+        map.put("id", ITEM_ID);
+
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(map);
+        doReturn(ERIC_IDENTITY_VALUE).when(request).getHeader(ERIC_IDENTITY_HEADER_NAME);
+        doReturn(ERIC_IDENTITY_TYPE_OAUTH2_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME);
+        when(service.getMissingImageDeliveryItemById(ITEM_ID)).thenReturn(Optional.empty());
+
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Authorise if GET and an API key is used")
+    public void willAuthoriseIfRequestIsGetAndAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        when(request.getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME)).thenReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE);
+        assertTrue(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not Authorise if POST and an API key is used")
+    public void willNotAuthoriseIfRequestIsPostAndAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(request.getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME)).thenReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not Authorise if POST and unrecognised identity type")
+    public void willNotAuthoriseIfRequestIsPostAndUnrecognisedIdentity() {
+        when(request.getHeader(ERIC_IDENTITY_TYPE_HEADER_NAME)).thenReturn(INVALID_IDENTITY_TYPE_VALUE);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptorTest.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
+
+public class UserAuthorisationInterceptorTest {
+}

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
@@ -8,6 +8,7 @@ public class TestConstants {
     public static final String ERIC_IDENTITY_VALUE = "Y2VkZWVlMzhlZWFjY2M4MzQ3MT";
     public static final String ERIC_IDENTITY_TYPE_OAUTH2_VALUE = "oauth2";
     public static final String ERIC_IDENTITY_TYPE_HEADER_NAME = "ERIC-Identity-Type";
+    public static final String ERIC_IDENTITY_TYPE_API_KEY_VALUE = "key";
     public static final String MISSING_IMAGE_DELIVERY_URL = "/orderable/missing-image-deliveries";
     public static final ApiErrorResponsePayload FILING_NOT_FOUND =
         new ApiErrorResponsePayload(singletonList(new Error("ch:service", "filing-history-item-not-found")));


### PR DESCRIPTION
Add authorisation to MID api to ensure requests meet the standards to view MID items

Resolves: GCI-456