### PR TITLE
Add support for filing history category attribute

### DIFF
--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/model/MissingImageDeliveryItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/model/MissingImageDeliveryItemOptions.java
@@ -11,12 +11,14 @@ public class MissingImageDeliveryItemOptions {
                                      final String filingHistoryDescription,
                                      final Map<String, Object> filingHistoryDescriptionValues,
                                      final String filingHistoryId,
-                                     final String filingHistoryType) {
+                                     final String filingHistoryType,
+                                     final String filingHistoryCategory) {
         this.filingHistoryDate = filingHistoryDate;
         this.filingHistoryDescription = filingHistoryDescription;
         this.filingHistoryDescriptionValues = filingHistoryDescriptionValues;
         this.filingHistoryId = filingHistoryId;
         this.filingHistoryType = filingHistoryType;
+        this.filingHistoryCategory = filingHistoryCategory;
     }
 
     private String filingHistoryDate;
@@ -28,6 +30,8 @@ public class MissingImageDeliveryItemOptions {
     private String filingHistoryId;
 
     private String filingHistoryType;
+
+    private String filingHistoryCategory;
 
     private String filingHistoryCost;
 
@@ -70,6 +74,12 @@ public class MissingImageDeliveryItemOptions {
     public void setFilingHistoryType(String filingHistoryType) {
         this.filingHistoryType = filingHistoryType;
     }
+
+    public String getFilingHistoryCategory() {
+        return filingHistoryCategory;
+    }
+
+    public void setFilingHistoryCategory(String filingHistoryCategory) { this.filingHistoryCategory = filingHistoryCategory; }
 
     public String getFilingHistoryCost() {
         return filingHistoryCost;

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentService.java
@@ -54,7 +54,8 @@ public class FilingHistoryDocumentService {
                         filing.getDescription(),
                         filing.getDescriptionValues(),
                         filing.getTransactionId(),
-                        filing.getType());
+                        filing.getType(),
+                        filing.getCategory());
         } catch (ApiErrorResponseException ex) {
             throw getResponseStatusException(ex, apiClient, companyNumber, filingHistoryDocumentId, uri);
         } catch (URIValidationException ex) {

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
@@ -72,6 +72,7 @@ class MissingImageDeliveryItemControllerIntegrationTest {
     private static final String TOKEN_ETAG = "9d39ea69b64c80ca42ed72328b48c303c4445e28";
     private static final String POSTAGE_COST = "0";
     public static final String FILING_HISTORY_TYPE_CH01 = "CH01";
+    public static final String FILING_HISTORY_CATEGORY_ACCOUNTS = "accounts";
     private static final String KIND = "item#missing-image-delivery";
     private static final boolean POSTAL_DELIVERY = false;
 
@@ -133,7 +134,8 @@ class MissingImageDeliveryItemControllerIntegrationTest {
                 FILING_HISTORY_DESCRIPTION,
                 FILING_HISTORY_DESCRIPTION_VALUES,
                 FILING_HISTORY_ID,
-                FILING_HISTORY_TYPE_CH01);
+                FILING_HISTORY_TYPE_CH01,
+                FILING_HISTORY_CATEGORY_ACCOUNTS);
 
         when(idGeneratorService.autoGenerateId()).thenReturn(MISSING_IMAGE_DELIVERY_ID);
         when(etagGeneratorService.generateEtag()).thenReturn(TOKEN_ETAG);
@@ -178,7 +180,9 @@ class MissingImageDeliveryItemControllerIntegrationTest {
                 .andExpect(jsonPath("$.item_options.filing_history_id",
                     is(FILING_HISTORY_ID)))
                 .andExpect(jsonPath("$.item_options.filing_history_type",
-                    is(FILING_HISTORY_TYPE_CH01)));
+                    is(FILING_HISTORY_TYPE_CH01)))
+                .andExpect(jsonPath("$.item_options.filing_history_category",
+                        is(FILING_HISTORY_CATEGORY_ACCOUNTS)));
 
         final MissingImageDeliveryItem retrievedItem = assertItemSavedCorrectly(MISSING_IMAGE_DELIVERY_ID);
         final LocalDateTime intervalEnd = LocalDateTime.now();
@@ -204,6 +208,7 @@ class MissingImageDeliveryItemControllerIntegrationTest {
         assertThat(retrievedItem.getItemOptions().getFilingHistoryDescriptionValues(), is(FILING_HISTORY_DESCRIPTION_VALUES));
         assertThat(retrievedItem.getItemOptions().getFilingHistoryId(), is(FILING_HISTORY_ID));
         assertThat(retrievedItem.getItemOptions().getFilingHistoryType(), is(FILING_HISTORY_TYPE_CH01));
+        assertThat(retrievedItem.getItemOptions().getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY_ACCOUNTS));
     }
 
     @Test
@@ -231,7 +236,8 @@ class MissingImageDeliveryItemControllerIntegrationTest {
         item.setPostageCost(POSTAGE_COST);
         item.setUserId(ERIC_IDENTITY_VALUE);
         final MissingImageDeliveryItemOptions itemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
-                FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE_CH01);
+                FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE_CH01,
+                FILING_HISTORY_CATEGORY_ACCOUNTS);
         item.setItemOptions(itemOptions);
         repository.save(item);
 

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -64,11 +64,17 @@ class FilingHistoryDocumentServiceIntegrationTest {
             "accounts-with-accounts-type-group",
             Collections.singletonMap("made_up_date", "2004-08-31"),
             ID_1,
-            "AA"
+            "AA",
+            "accounts"
     );
 
     private static final MissingImageDeliveryItemOptions FILING_SOUGHT =
-        new MissingImageDeliveryItemOptions(null, null, null, ID_1, null);
+        new MissingImageDeliveryItemOptions(null,
+                null,
+                null,
+                ID_1,
+                null,
+                null);
 
     private static final MissingImageDeliveryItemOptions FILING_EXPECTED = FILING_1;
 
@@ -199,6 +205,7 @@ class FilingHistoryDocumentServiceIntegrationTest {
         filing.setDescriptionValues(document.getFilingHistoryDescriptionValues());
         filing.setDescription(document.getFilingHistoryDescription());
         filing.setType(document.getFilingHistoryType());
+        filing.setCategory(document.getFilingHistoryCategory());
         return filing;
     }
 

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
@@ -44,6 +44,7 @@ public class MissingImageDeliveryItemServiceTest {
     private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
     private static final Map<String, Object> FILING_HISTORY_DESCRIPTION_VALUES = new HashMap<>();
     private static final String FILING_HISTORY_TYPE = "CH01";
+    public static final String FILING_HISTORY_CATEGORY = "accounts";
     private static final int QUANTITY = 1;
     private static final String KIND = "item#missing-image-delivery";
 
@@ -80,7 +81,8 @@ public class MissingImageDeliveryItemServiceTest {
         // Given
         when(idGeneratorService.autoGenerateId()).thenReturn(ID);
         final MissingImageDeliveryItemOptions midItemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
-                FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE);
+                FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE,
+                FILING_HISTORY_CATEGORY);
         when(costCalculatorService.calculateCosts(QUANTITY)).thenReturn(CALCULATION);
         MissingImageDeliveryItemData missingImageDeliveryItemData = new MissingImageDeliveryItemData();
         missingImageDeliveryItemData.setCompanyNumber(COMPANY_NUMBER);
@@ -118,6 +120,7 @@ public class MissingImageDeliveryItemServiceTest {
                 is(FILING_HISTORY_DESCRIPTION_VALUES));
         assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryId(), is(FILING_HISTORY_ID));
         assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryType(), is(FILING_HISTORY_TYPE));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY));
         verify(repository).save(missingImageDeliveryItem);
     }
 


### PR DESCRIPTION
Adds `filinigHistoryCategory` attribute to `MissingImageDeliveryItemOptions`