### PR TITLE
Add interceptor to check token permissions 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
 
     <properties>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
-		<api-sdk-java.version>4.2.36</api-sdk-java.version>
+        <api-sdk-java.version>4.2.36</api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
-        <api-security-java.version>0.2.10</api-security-java.version>
+        <api-security-java.version>0.2.14</api-security-java.version>
         <commons.lang.version>2.6</commons.lang.version>
         <guava.version>28.1-jre</guava.version>
         <gson.version>2.8.0</gson.version>

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
@@ -18,7 +18,6 @@ import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
 import uk.gov.companieshouse.api.util.security.Permission.Key;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthenticationInterceptor;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthorisationInterceptor;
-import uk.gov.companieshouse.missingimagedelivery.orders.api.service.MissingImageDeliveryItemService;
 
 @Configuration
 public class ApplicationConfiguration implements WebMvcConfigurer {
@@ -27,17 +26,22 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     private String MISSING_IMAGE_DELIVERY_HOME;
 
     @Autowired
-    private MissingImageDeliveryItemService missingImageDeliveryItemService;
+    private UserAuthenticationInterceptor userAuthenticationInterceptor;
+
+    @Autowired
+    private UserAuthorisationInterceptor userAuthorisationInterceptor;
+
+    @Autowired
+    private CRUDAuthenticationInterceptor crudPermissionsInterceptor;
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         final String authPathPattern = MISSING_IMAGE_DELIVERY_HOME + "/**";
         final String healthCheckPathPattern = MISSING_IMAGE_DELIVERY_HOME + "/healthcheck";
-        registry.addInterceptor(new UserAuthenticationInterceptor()).addPathPatterns(authPathPattern)
+        registry.addInterceptor(userAuthenticationInterceptor).addPathPatterns(authPathPattern)
                 .excludePathPatterns(healthCheckPathPattern);
-        registry.addInterceptor(new UserAuthorisationInterceptor(missingImageDeliveryItemService)).addPathPatterns(authPathPattern);
-        registry.addInterceptor(crudPermissionsInterceptor())
-                .addPathPatterns(authPathPattern)
+        registry.addInterceptor(userAuthorisationInterceptor).addPathPatterns(authPathPattern);
+        registry.addInterceptor(crudPermissionsInterceptor).addPathPatterns(authPathPattern)
                 .excludePathPatterns(healthCheckPathPattern);
     }
 

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAut
 public class ApplicationConfiguration implements WebMvcConfigurer {
 
     @Value("${uk.gov.companieshouse.missingimagedelivery.orders.api.home}")
-    private String MISSING_IMAGE_DELIVERY_HOME;
+    String missingImageDeliveryHome;
 
     @Autowired
     private UserAuthenticationInterceptor userAuthenticationInterceptor;
@@ -36,8 +36,8 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        final String authPathPattern = MISSING_IMAGE_DELIVERY_HOME + "/**";
-        final String healthCheckPathPattern = MISSING_IMAGE_DELIVERY_HOME + "/healthcheck";
+        final String authPathPattern = missingImageDeliveryHome + "/**";
+        final String healthCheckPathPattern = missingImageDeliveryHome + "/healthcheck";
         registry.addInterceptor(userAuthenticationInterceptor).addPathPatterns(authPathPattern)
                 .excludePathPatterns(healthCheckPathPattern);
         registry.addInterceptor(userAuthorisationInterceptor).addPathPatterns(authPathPattern);

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfiguration.java
@@ -1,20 +1,24 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.config;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthenticationInterceptor;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthorisationInterceptor;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.service.MissingImageDeliveryItemService;
-
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
 
 @Configuration
 public class ApplicationConfiguration implements WebMvcConfigurer {
@@ -27,9 +31,14 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(new UserAuthenticationInterceptor()).addPathPatterns(MISSING_IMAGE_DELIVERY_HOME + "/**")
-                .excludePathPatterns(MISSING_IMAGE_DELIVERY_HOME + "/healthcheck");
-        registry.addInterceptor(new UserAuthorisationInterceptor(missingImageDeliveryItemService)).addPathPatterns(MISSING_IMAGE_DELIVERY_HOME + "/**");
+        final String authPathPattern = MISSING_IMAGE_DELIVERY_HOME + "/**";
+        final String healthCheckPathPattern = MISSING_IMAGE_DELIVERY_HOME + "/healthcheck";
+        registry.addInterceptor(new UserAuthenticationInterceptor()).addPathPatterns(authPathPattern)
+                .excludePathPatterns(healthCheckPathPattern);
+        registry.addInterceptor(new UserAuthorisationInterceptor(missingImageDeliveryItemService)).addPathPatterns(authPathPattern);
+        registry.addInterceptor(crudPermissionsInterceptor())
+                .addPathPatterns(authPathPattern)
+                .excludePathPatterns(healthCheckPathPattern);
     }
 
     @Bean
@@ -42,4 +51,8 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
                 .findAndRegisterModules();
     }
 
+    @Bean
+    public CRUDAuthenticationInterceptor crudPermissionsInterceptor() {
+        return new CRUDAuthenticationInterceptor(Key.USER_ORDERS);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthenticationInterceptor.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
 
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.util.EricHeaderHelper;
@@ -15,6 +16,7 @@ import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.Logg
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.STATUS_LOG_KEY;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.getLogger;
 
+@Component
 public class UserAuthenticationInterceptor extends HandlerInterceptorAdapter {
 
     private static final Logger LOGGER = getLogger();

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/UserAuthorisationInterceptor.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
 
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import uk.gov.companieshouse.logging.Logger;
@@ -26,6 +27,7 @@ import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.Logg
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.USER_ID_LOG_KEY;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.getLogger;
 
+@Component
 public class UserAuthorisationInterceptor extends HandlerInterceptorAdapter {
 
     private final MissingImageDeliveryItemService service;

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/config/ApplicationConfigurationTest.java
@@ -1,0 +1,75 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.config;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthenticationInterceptor;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.UserAuthorisationInterceptor;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationConfigurationTest {
+
+    private static final String CERTIFIED_COPIES_HOME = "/orderable/certified-copies";
+
+    @Mock
+    private UserAuthenticationInterceptor userAuthenticationInterceptor;
+
+    @Mock
+    private UserAuthorisationInterceptor userAuthorisationInterceptor;
+
+    @Mock
+    private CRUDAuthenticationInterceptor crudPermissionInterceptor;
+
+    @InjectMocks
+    private ApplicationConfiguration config;
+
+    @BeforeEach
+    void setup() {
+        config.missingImageDeliveryHome = CERTIFIED_COPIES_HOME;
+    }
+
+    @Test
+    void addInterceptors() {
+        final String expectedAuthPathPattern = CERTIFIED_COPIES_HOME + "/**";
+        final String expectedExcludedPathPattern = CERTIFIED_COPIES_HOME + "/healthcheck";
+
+        InterceptorRegistry registry = Mockito.mock(InterceptorRegistry.class);
+
+        InterceptorRegistration userAuthenticationInterceptorRegistration = Mockito.mock(InterceptorRegistration.class);
+        doReturn(userAuthenticationInterceptorRegistration).when(registry).addInterceptor(userAuthenticationInterceptor);
+        doReturn(userAuthenticationInterceptorRegistration).when(userAuthenticationInterceptorRegistration).addPathPatterns(expectedAuthPathPattern);
+
+        InterceptorRegistration userAuthorisationInterceptorRegistration = Mockito.mock(InterceptorRegistration.class);
+        doReturn(userAuthorisationInterceptorRegistration).when(registry).addInterceptor(userAuthorisationInterceptor);
+
+        InterceptorRegistration crudPermissionInterceptorRegistration = Mockito.mock(InterceptorRegistration.class);
+        doReturn(crudPermissionInterceptorRegistration).when(registry).addInterceptor(crudPermissionInterceptor);
+        doReturn(crudPermissionInterceptorRegistration).when(crudPermissionInterceptorRegistration).addPathPatterns(expectedAuthPathPattern);
+
+        config.addInterceptors(registry);
+
+        verify(userAuthenticationInterceptorRegistration).addPathPatterns(expectedAuthPathPattern);
+        verify(userAuthenticationInterceptorRegistration).excludePathPatterns(expectedExcludedPathPattern);
+        verify(userAuthorisationInterceptorRegistration).addPathPatterns(expectedAuthPathPattern);
+        verify(crudPermissionInterceptorRegistration).addPathPatterns(expectedAuthPathPattern);
+        verify(crudPermissionInterceptorRegistration).excludePathPatterns(expectedExcludedPathPattern);
+
+        InOrder inOrder = Mockito.inOrder(registry);
+        inOrder.verify(registry).addInterceptor(userAuthenticationInterceptor);
+        inOrder.verify(registry).addInterceptor(userAuthorisationInterceptor);
+        inOrder.verify(registry).addInterceptor(crudPermissionInterceptor);
+    }
+
+}


### PR DESCRIPTION
Add interceptor to check that the user has the required token permission based on the request HTTP method
Refactor to use dependency injection for the interceptors and facilitate unit testing

Resolve FA-966