### PR TITLE
Implement use of filing history barcode 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/model/MissingImageDeliveryItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/model/MissingImageDeliveryItemOptions.java
@@ -12,13 +12,15 @@ public class MissingImageDeliveryItemOptions {
                                      final Map<String, Object> filingHistoryDescriptionValues,
                                      final String filingHistoryId,
                                      final String filingHistoryType,
-                                     final String filingHistoryCategory) {
+                                     final String filingHistoryCategory,
+                                     final String filingHistoryBarcode) {
         this.filingHistoryDate = filingHistoryDate;
         this.filingHistoryDescription = filingHistoryDescription;
         this.filingHistoryDescriptionValues = filingHistoryDescriptionValues;
         this.filingHistoryId = filingHistoryId;
         this.filingHistoryType = filingHistoryType;
         this.filingHistoryCategory = filingHistoryCategory;
+        this.filingHistoryBarcode = filingHistoryBarcode;
     }
 
     private String filingHistoryDate;
@@ -34,6 +36,8 @@ public class MissingImageDeliveryItemOptions {
     private String filingHistoryCategory;
 
     private String filingHistoryCost;
+
+    private String filingHistoryBarcode;
 
     public String getFilingHistoryDate() {
         return filingHistoryDate;
@@ -87,6 +91,14 @@ public class MissingImageDeliveryItemOptions {
 
     public void setFilingHistoryCost(String filingHistoryCost) {
         this.filingHistoryCost = filingHistoryCost;
+    }
+
+    public String getFilingHistoryBarcode() {
+        return filingHistoryBarcode;
+    }
+
+    public void setFilingHistoryBarcode(String filingHistoryBarcode) {
+        this.filingHistoryBarcode = filingHistoryBarcode;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentService.java
@@ -55,7 +55,8 @@ public class FilingHistoryDocumentService {
                         filing.getDescriptionValues(),
                         filing.getTransactionId(),
                         filing.getType(),
-                        filing.getCategory());
+                        filing.getCategory(),
+                        filing.getBarcode());
         } catch (ApiErrorResponseException ex) {
             throw getResponseStatusException(ex, apiClient, companyNumber, filingHistoryDocumentId, uri);
         } catch (URIValidationException ex) {

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
@@ -81,6 +81,7 @@ class MissingImageDeliveryItemControllerIntegrationTest {
     private static final String POSTAGE_COST = "0";
     public static final String FILING_HISTORY_TYPE_CH01 = "CH01";
     public static final String FILING_HISTORY_CATEGORY_ACCOUNTS = "accounts";
+    public static final String FILING_HISTORY_BARCODE = "0006578";
     private static final String KIND = "item#missing-image-delivery";
     private static final boolean POSTAL_DELIVERY = false;
 
@@ -145,7 +146,8 @@ class MissingImageDeliveryItemControllerIntegrationTest {
                 FILING_HISTORY_DESCRIPTION_VALUES,
                 FILING_HISTORY_ID,
                 FILING_HISTORY_TYPE_CH01,
-                FILING_HISTORY_CATEGORY_ACCOUNTS);
+                FILING_HISTORY_CATEGORY_ACCOUNTS,
+                FILING_HISTORY_BARCODE);
 
         when(idGeneratorService.autoGenerateId()).thenReturn(MISSING_IMAGE_DELIVERY_ID);
         when(etagGeneratorService.generateEtag()).thenReturn(TOKEN_ETAG);
@@ -192,7 +194,9 @@ class MissingImageDeliveryItemControllerIntegrationTest {
                 .andExpect(jsonPath("$.item_options.filing_history_type",
                     is(FILING_HISTORY_TYPE_CH01)))
                 .andExpect(jsonPath("$.item_options.filing_history_category",
-                        is(FILING_HISTORY_CATEGORY_ACCOUNTS)));
+                        is(FILING_HISTORY_CATEGORY_ACCOUNTS)))
+                .andExpect((jsonPath("$.item_options.filing_history_barcode",
+                        is(FILING_HISTORY_BARCODE))));
 
         final MissingImageDeliveryItem retrievedItem = assertItemSavedCorrectly(MISSING_IMAGE_DELIVERY_ID);
         final LocalDateTime intervalEnd = LocalDateTime.now();
@@ -219,6 +223,7 @@ class MissingImageDeliveryItemControllerIntegrationTest {
         assertThat(retrievedItem.getItemOptions().getFilingHistoryId(), is(FILING_HISTORY_ID));
         assertThat(retrievedItem.getItemOptions().getFilingHistoryType(), is(FILING_HISTORY_TYPE_CH01));
         assertThat(retrievedItem.getItemOptions().getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY_ACCOUNTS));
+        assertThat(retrievedItem.getItemOptions().getFilingHistoryBarcode(), is(FILING_HISTORY_BARCODE));
     }
 
     @Test
@@ -247,7 +252,7 @@ class MissingImageDeliveryItemControllerIntegrationTest {
         item.setUserId(ERIC_IDENTITY_VALUE);
         final MissingImageDeliveryItemOptions itemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
                 FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE_CH01,
-                FILING_HISTORY_CATEGORY_ACCOUNTS);
+                FILING_HISTORY_CATEGORY_ACCOUNTS, FILING_HISTORY_BARCODE);
         item.setItemOptions(itemOptions);
         repository.save(item);
 

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/mapper/MissingImageDeliveryItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/mapper/MissingImageDeliveryItemMapperTest.java
@@ -44,6 +44,7 @@ class MissingImageDeliveryItemMapperTest {
 	private static final String FILING_HISTORY_ID = "MzAwOTM2MDg5OWFkaXF6a2N5";
 	private static final String FILING_HISTORY_DATE = "2010-02-12";
 	private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
+	private static final String FILING_HISTORY_BARCODE = "0005668";
 	private static final Map<String, Object> FILING_HISTORY_DESCRIPTION_VALUES;
 
 	private static final Links LINKS;
@@ -59,6 +60,7 @@ class MissingImageDeliveryItemMapperTest {
 		ITEM_OPTIONS.setFilingHistoryDescriptionValues(FILING_HISTORY_DESCRIPTION_VALUES);
 		ITEM_OPTIONS.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
 		ITEM_OPTIONS.setFilingHistoryDate(FILING_HISTORY_DATE);
+		ITEM_OPTIONS.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
 
 		LINKS = new Links();
 		LINKS.setSelf("self");
@@ -129,6 +131,7 @@ class MissingImageDeliveryItemMapperTest {
 		assertThat(dto.getItemOptions().getFilingHistoryId(), is(item.getItemOptions().getFilingHistoryId()));
 		assertThat(dto.getItemOptions().getFilingHistoryDescription(), is(item.getItemOptions().getFilingHistoryDescription()));
 		assertThat(dto.getItemOptions().getFilingHistoryDescriptionValues(), is(item.getItemOptions().getFilingHistoryDescriptionValues()));
+		assertThat(dto.getItemOptions().getFilingHistoryBarcode(), is(item.getItemOptions().getFilingHistoryBarcode()));
 		assertThat(dto.getItemOptions().getFilingHistoryDate(), is(item.getItemOptions().getFilingHistoryDate()));
 		assertThat(dto.getKind(), is(item.getKind()));
 		assertThat(dto.getLinks().getSelf(), is(item.getLinks().getSelf()));

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -65,7 +65,8 @@ class FilingHistoryDocumentServiceIntegrationTest {
             Collections.singletonMap("made_up_date", "2004-08-31"),
             ID_1,
             "AA",
-            "accounts"
+            "accounts",
+            "00503271"
     );
 
     private static final MissingImageDeliveryItemOptions FILING_SOUGHT =
@@ -74,7 +75,9 @@ class FilingHistoryDocumentServiceIntegrationTest {
                 null,
                 ID_1,
                 null,
-                null);
+                null,
+                null
+            );
 
     private static final MissingImageDeliveryItemOptions FILING_EXPECTED = FILING_1;
 
@@ -206,6 +209,7 @@ class FilingHistoryDocumentServiceIntegrationTest {
         filing.setDescription(document.getFilingHistoryDescription());
         filing.setType(document.getFilingHistoryType());
         filing.setCategory(document.getFilingHistoryCategory());
+        filing.setBarcode(document.getFilingHistoryBarcode());
         return filing;
     }
 

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
@@ -45,6 +45,7 @@ public class MissingImageDeliveryItemServiceTest {
     private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
     private static final Map<String, Object> FILING_HISTORY_DESCRIPTION_VALUES = new HashMap<>();
     private static final String FILING_HISTORY_TYPE = "CH01";
+    private static final String FILING_HISTORY_BARCODE = "00503271";
     private static final int QUANTITY = 1;
     private static final String KIND = "item#missing-image-delivery";
 
@@ -85,7 +86,7 @@ public class MissingImageDeliveryItemServiceTest {
         when(idGeneratorService.autoGenerateId()).thenReturn(ID);
         final MissingImageDeliveryItemOptions midItemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
                 FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE,
-                FILING_HISTORY_CATEGORY);
+                FILING_HISTORY_CATEGORY, FILING_HISTORY_BARCODE);
         when(costCalculatorService.calculateCosts(QUANTITY, MISC_PRODUCT_TYPE)).thenReturn(CALCULATION);
         MissingImageDeliveryItemData missingImageDeliveryItemData = new MissingImageDeliveryItemData();
         missingImageDeliveryItemData.setCompanyNumber(COMPANY_NUMBER);
@@ -124,6 +125,7 @@ public class MissingImageDeliveryItemServiceTest {
         assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryId(), is(FILING_HISTORY_ID));
         assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryType(), is(FILING_HISTORY_TYPE));
         assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryBarcode(), is(FILING_HISTORY_BARCODE));
         verify(repository).save(missingImageDeliveryItem);
     }
 


### PR DESCRIPTION
Use the barcode from filing api to populate filing history barcode within the MID item

Resolves: GCI-1597