### PR TITLE
Remove Spring Data Rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <api-sdk-java.version>4.2.36</api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
-        <api-security-java.version>0.2.16</api-security-java.version>
+        <api-security-java.version>0.3.0</api-security-java.version>
         <commons.lang.version>2.6</commons.lang.version>
         <guava.version>28.1-jre</guava.version>
         <gson.version>2.8.0</gson.version>
@@ -56,11 +56,11 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-rest</artifactId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/repository/MissingImageDeliveryItemRepository.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/repository/MissingImageDeliveryItemRepository.java
@@ -1,9 +1,10 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
 
-@RepositoryRestResource
+@Repository
 public interface MissingImageDeliveryItemRepository extends MongoRepository<MissingImageDeliveryItem, String> {
 }


### PR DESCRIPTION
Using `@RepositoryRestResource` is generating a separate set of endpoints that we do not want to expose so removing the Spring Data REST dependency and keep just our defined endpoints.
Upgrade `api-security-java.version` to latest version to fix dependency issues caused by transitive dependencies after removing Spring Data REST