### PR TITLE
Feature/bi 12446/implement free item calculation for admin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </parent>
     <artifactId>missing-image-delivery.orders.api.ch.gov.uk</artifactId>
     <version>unversioned</version>

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemRequestDTO;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemResponseDTO;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.EricAuthoriser;
@@ -40,8 +39,6 @@ import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.Logg
 @RestController
 public class MissingImageDeliveryItemController {
 
-    private static final Logger LOGGER = LoggingUtils.getLogger();
-
     private final MissingImageDeliveryItemMapper mapper;
     private final CompanyService companyService;
     private final MissingImageDeliveryItemService missingImageDeliveryItemService;
@@ -68,8 +65,7 @@ public class MissingImageDeliveryItemController {
 
         Map<String, Object> logMap = LoggingUtils.createLoggingDataMap(requestId);
         LoggingUtils.getLogger().infoRequest(request, "create missing image delivery item request", logMap);
-        final boolean entitledToFreeCertificates = ericAuthoriser.hasPermission("/admin/free-certs",  request);
-        LOGGER.info(String.valueOf(entitledToFreeCertificates));
+        final boolean entitledToFreeCertificates = ericAuthoriser.hasPermission("/admin/free-mids",  request);
         MissingImageDeliveryItem item = mapper.missingImageDeliveryItemRequestDTOtoMissingImageDeliveryItem(missingImageDeliveryItemRequestDTO);
 
         item.setUserId(EricHeaderHelper.getIdentity(request));

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemRequestDTO;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemResponseDTO;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.EricAuthoriser;
@@ -29,11 +31,7 @@ import java.util.Optional;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.COMPANY_NUMBER_LOG_KEY;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.REQUEST_ID_HEADER_NAME;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.MISSING_IMAGE_DELIVERY_ID_LOG_KEY;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.STATUS_LOG_KEY;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.USER_ID_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.*;
 
 
 @RestController
@@ -43,7 +41,7 @@ public class MissingImageDeliveryItemController {
     private final CompanyService companyService;
     private final MissingImageDeliveryItemService missingImageDeliveryItemService;
     private final FilingHistoryDocumentService filingHistoryDocumentService;
-    private EricAuthoriser ericAuthoriser;
+    private final EricAuthoriser ericAuthoriser;
 
     public MissingImageDeliveryItemController(final MissingImageDeliveryItemMapper mapper,
                                         final CompanyService companyService,

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
@@ -7,8 +7,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemRequestDTO;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemResponseDTO;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.EricAuthoriser;
@@ -77,7 +75,7 @@ public class MissingImageDeliveryItemController {
 
         item.getData().setItemOptions(filing);
 
-        MissingImageDeliveryItem createdItem = missingImageDeliveryItemService.createMissingImageDeliveryItem(item, entitledToFreeCertificates);
+        var createdItem = missingImageDeliveryItemService.createMissingImageDeliveryItem(item, entitledToFreeCertificates);
 
         logMap.put(USER_ID_LOG_KEY, createdItem.getUserId());
         logMap.put(COMPANY_NUMBER_LOG_KEY, createdItem.getCompanyNumber());

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
@@ -29,7 +29,11 @@ import java.util.Optional;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.*;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.REQUEST_ID_HEADER_NAME;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.USER_ID_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.COMPANY_NUMBER_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.MISSING_IMAGE_DELIVERY_ID_LOG_KEY;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.STATUS_LOG_KEY;
 
 
 @RestController

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriser.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriser.java
@@ -8,13 +8,9 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
-import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.EricHeaderHelper.ERIC_AUTHORISED_ROLES;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
 
@@ -34,7 +30,7 @@ class EricAuthoriser {
         final String authorisedRolesHeader = request.getHeader(ERIC_AUTHORISED_ROLES);
 
         LOGGER.debug("Checking " + ERIC_AUTHORISED_ROLES + " header with value `"
-                +  authorisedRolesHeader +"` for permission `" + permission + "`.");
+                + authorisedRolesHeader + "` for permission `" + permission + "`.");
 
         if (isNull(authorisedRolesHeader)) {
             return false;
@@ -43,14 +39,4 @@ class EricAuthoriser {
         final Set<String> permissions = stringHelper.asSet("\\s+", authorisedRolesHeader);
         return permissions.contains(permission);
     }
-//    private static Set<String> asSet(final String values) {
-//        if (values == null || values.trim().isEmpty()) {
-//            return Collections.emptySet();
-//        }
-//        return Arrays.stream(values.split(" "))
-//                .filter(s -> !s.isEmpty())
-//                .collect(Collectors.toSet());
-//    }
-
-
 }

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriser.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriser.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
+
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.util.StringHelper;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
+import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.EricHeaderHelper.ERIC_AUTHORISED_ROLES;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
+
+@Component
+public
+class EricAuthoriser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
+
+    private final StringHelper stringHelper;
+
+    public EricAuthoriser(final StringHelper stringHelper) {
+        this.stringHelper = stringHelper;
+    }
+
+    public boolean hasPermission(final String permission, final HttpServletRequest request) {
+        final String authorisedRolesHeader = request.getHeader(ERIC_AUTHORISED_ROLES);
+
+        LOGGER.debug("Checking " + ERIC_AUTHORISED_ROLES + " header with value `"
+                +  authorisedRolesHeader +"` for permission `" + permission + "`.");
+
+        if (isNull(authorisedRolesHeader)) {
+            return false;
+        }
+
+        final Set<String> permissions = stringHelper.asSet("\\s+", authorisedRolesHeader);
+        return permissions.contains(permission);
+    }
+//    private static Set<String> asSet(final String values) {
+//        if (values == null || values.trim().isEmpty()) {
+//            return Collections.emptySet();
+//        }
+//        return Arrays.stream(values.split(" "))
+//                .filter(s -> !s.isEmpty())
+//                .collect(Collectors.toSet());
+//    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
@@ -1,9 +1,7 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.service;
 
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.config.CostsConfig;
-import uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ItemCostCalculation;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ItemCosts;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ProductType;
@@ -19,8 +17,6 @@ public class MissingImageDeliveryCostCalculatorService {
     private static final String ZERO_POSTAGE_COST = "0";      // Postage is not applicable to MID.
 
     private final CostsConfig costs;
-    private static final Logger LOGGER = LoggingUtils.getLogger();
-
     /**
      * Constructor.
      * @param costs the configured costs used by this in its calculations
@@ -39,22 +35,15 @@ public class MissingImageDeliveryCostCalculatorService {
         checkArguments(quantity);
         final int basicCost = costs.getMissingImageDeliveryItemCost();
         final int calculatedCost;
-
-        LOGGER.info("userGetsFreeCertificates at calculateCosts : " + userGetsFreeCertificates );
         if (userGetsFreeCertificates) {
             calculatedCost = 0;
         } else {
             calculatedCost = basicCost;
         }
-        //If the user has permission, discount is calculated which is based on the total basic cost so no pay is needed
+        // If the user has permission, discount is calculated which is based on the total basic cost so no pay is needed
         final String discountApplied = userGetsFreeCertificates ? Integer.toString(basicCost) : "0";
         final String itemCost = Integer.toString(basicCost);
         final String totalItemCost = Integer.toString(quantity * calculatedCost);
-
-        LOGGER.info("discount : " + discountApplied );
-        LOGGER.info("itemCost : " + itemCost );
-
-        LOGGER.info("totalItemCost : " + totalItemCost );
         return new ItemCostCalculation(
                 singletonList(new ItemCosts(discountApplied,
                         itemCost,

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
@@ -34,12 +34,7 @@ public class MissingImageDeliveryCostCalculatorService {
     public ItemCostCalculation calculateCosts(final int quantity, final ProductType productType, final boolean userGetsFreeCertificates) {
         checkArguments(quantity);
         final int basicCost = costs.getMissingImageDeliveryItemCost();
-        final int calculatedCost;
-        if (userGetsFreeCertificates) {
-            calculatedCost = 0;
-        } else {
-            calculatedCost = basicCost;
-        }
+        final int calculatedCost = userGetsFreeCertificates ? 0 : basicCost;
         // If the user has permission, discount is calculated which is based on the total basic cost so no pay is needed
         final String discountApplied = userGetsFreeCertificates ? Integer.toString(basicCost) : "0";
         final var itemCost = Integer.toString(basicCost);

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
@@ -32,7 +32,7 @@ public class MissingImageDeliveryCostCalculatorService {
      *
      * @param quantity                 the number of items
      * @param productType              product type based on category
-     * @param userGetsFreeCertificates
+     * @param userGetsFreeCertificates if user has permission admin/free-mids, return true
      * @return all of the relevant costs
      */
     public ItemCostCalculation calculateCosts(final int quantity, final ProductType productType, final boolean userGetsFreeCertificates) {

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorService.java
@@ -42,8 +42,8 @@ public class MissingImageDeliveryCostCalculatorService {
         }
         // If the user has permission, discount is calculated which is based on the total basic cost so no pay is needed
         final String discountApplied = userGetsFreeCertificates ? Integer.toString(basicCost) : "0";
-        final String itemCost = Integer.toString(basicCost);
-        final String totalItemCost = Integer.toString(quantity * calculatedCost);
+        final var itemCost = Integer.toString(basicCost);
+        final var totalItemCost = Integer.toString(quantity * calculatedCost);
         return new ItemCostCalculation(
                 singletonList(new ItemCosts(discountApplied,
                         itemCost,

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemService.java
@@ -1,8 +1,6 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.service;
 
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.FilingHistoryCategory;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ItemCostCalculation;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
@@ -27,8 +25,6 @@ public class MissingImageDeliveryItemService {
     private final LinksGeneratorService linksGenerator;
     private final MissingImageDeliveryCostCalculatorService calculator;
     private final DescriptionProviderService descriptionProviderService;
-
-    private static final Logger LOGGER = LoggingUtils.getLogger();
     private static final String DESCRIPTION_IDENTIFIER = "missing-image-delivery";
     private static final String COMPANY_NUMBER_KEY = "company_number";
 
@@ -66,9 +62,7 @@ public class MissingImageDeliveryItemService {
         MissingImageDeliveryItemOptions itemOptions = item.getItemOptions();
         String category = itemOptions.getFilingHistoryCategory();
         ProductType productType = FilingHistoryCategory.enumValueOf(category).getProductType();
-        LOGGER.info("User value before cost" + String.valueOf(userGetsFreeCertificates));
         final ItemCostCalculation costs = calculator.calculateCosts(item.getQuantity(), productType, userGetsFreeCertificates );
-        LOGGER.info("Item costs: " + costs);
         item.setItemCosts(costs.getItemCosts());
         item.setPostageCost(costs.getPostageCost());
         item.setTotalItemCost(costs.getTotalItemCost());

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemService.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.service;
 
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.FilingHistoryCategory;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ItemCostCalculation;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
@@ -26,6 +28,7 @@ public class MissingImageDeliveryItemService {
     private final MissingImageDeliveryCostCalculatorService calculator;
     private final DescriptionProviderService descriptionProviderService;
 
+    private static final Logger LOGGER = LoggingUtils.getLogger();
     private static final String DESCRIPTION_IDENTIFIER = "missing-image-delivery";
     private static final String COMPANY_NUMBER_KEY = "company_number";
 
@@ -51,7 +54,7 @@ public class MissingImageDeliveryItemService {
      * @param item the item to be created
      * @return the created item
      */
-    public MissingImageDeliveryItem createMissingImageDeliveryItem(final MissingImageDeliveryItem item) {
+    public MissingImageDeliveryItem createMissingImageDeliveryItem(final MissingImageDeliveryItem item, final boolean userGetsFreeCertificates) {
         item.setId(idGenerator.autoGenerateId());
         setCreationDateTimes(item);
         item.setEtag(etagGenerator.generateEtag());
@@ -63,7 +66,9 @@ public class MissingImageDeliveryItemService {
         MissingImageDeliveryItemOptions itemOptions = item.getItemOptions();
         String category = itemOptions.getFilingHistoryCategory();
         ProductType productType = FilingHistoryCategory.enumValueOf(category).getProductType();
-        final ItemCostCalculation costs = calculator.calculateCosts(item.getQuantity(), productType);
+        LOGGER.info("User value before cost" + String.valueOf(userGetsFreeCertificates));
+        final ItemCostCalculation costs = calculator.calculateCosts(item.getQuantity(), productType, userGetsFreeCertificates );
+        LOGGER.info("Item costs: " + costs);
         item.setItemCosts(costs.getItemCosts());
         item.setPostageCost(costs.getPostageCost());
         item.setTotalItemCost(costs.getTotalItemCost());

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/EricHeaderHelper.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/EricHeaderHelper.java
@@ -11,6 +11,8 @@ public class EricHeaderHelper {
 	public static final String ERIC_IDENTITY = "ERIC-Identity";
 	public static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
 
+	public static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
+
 	private EricHeaderHelper() {
 	}
 

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/StringHelper.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/StringHelper.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public final class StringHelper {
+
+    public Set<String> asSet(String regexDelim, String values) {
+        return Stream.of(Optional.ofNullable(values).orElse("").split(regexDelim))
+                .filter(StringUtils::isNotEmpty)
+                .collect(Collectors.toSet());
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
@@ -91,7 +91,6 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
     private static final String KIND = "item#missing-image-delivery";
     private static final boolean POSTAL_DELIVERY = false;
 
-    private static final boolean USER_ELIGIBLE_FREE_CERTIFICATES = true;
     private static final boolean USER_NOT_ELIGIBLE_FREE_CERTIFICATES = false;
 
     private static final ItemCostCalculation CALCULATION = new ItemCostCalculation(

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
@@ -91,6 +91,9 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
     private static final String KIND = "item#missing-image-delivery";
     private static final boolean POSTAL_DELIVERY = false;
 
+    private static final boolean USER_ELIGIBLE_FREE_CERTIFICATES = true;
+    private static final boolean USER_NOT_ELIGIBLE_FREE_CERTIFICATES = false;
+
     private static final ItemCostCalculation CALCULATION = new ItemCostCalculation(
             singletonList(new ItemCosts(DISCOUNT_APPLIED,
                     MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
@@ -162,7 +165,7 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
 
         when(idGeneratorService.autoGenerateId()).thenReturn(MISSING_IMAGE_DELIVERY_ID);
         when(etagGeneratorService.generateEtag()).thenReturn(TOKEN_ETAG);
-        when(calculatorService.calculateCosts(QUANTITY_1, ACCOUNTS_PRODUCT_TYPE)).thenReturn(CALCULATION);
+        when(calculatorService.calculateCosts(QUANTITY_1, ACCOUNTS_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES)).thenReturn(CALCULATION);
         when(companyService.getCompanyName(COMPANY_NUMBER)).thenReturn(COMPANY_NAME);
         when(filingHistoryDocumentService.getFilingHistoryDocument(eq(COMPANY_NUMBER), anyString())).thenReturn(filing);
 
@@ -348,6 +351,7 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
         verifyZeroInteractions(idGeneratorService);
 
     }
+
     private MissingImageDeliveryItem newMissingImageDeliveryItem() {
         final MissingImageDeliveryItemData itemData = new MissingImageDeliveryItemData();
         itemData.setCompanyName(COMPANY_NAME);
@@ -394,6 +398,7 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
     /**
      * Verifies that the missing image delivery item cannot in fact be retrieved
      * from the database.
+     *
      * @param missingImageDeliveryId the expected ID of the newly created item
      */
     private void assertItemWasNotSaved(final String missingImageDeliveryId) {

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
@@ -12,10 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.missingimagedelivery.orders.api.util.StringHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.Set;
 
+@SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class EricAuthoriserTest {
 
@@ -26,26 +27,21 @@ class EricAuthoriserTest {
     private static final String FREE_MIDS_HEADER_VALUE= "/admin/free-mids";
 
     @Mock
-    private StringHelper stringHelper;
-
-    @Mock
     private HttpServletRequest request;
 
+    @Autowired
     @InjectMocks
     private EricAuthoriser authoriser;
 
     @Test
     @DisplayName("Should return true when permission is present in the header")
     void shouldReturnTrueForValidPermission() {
-        final String headerValue = FREE_MIDS_HEADER_VALUE;
-        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(headerValue);
-        when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of("/admin/free-mids"));
+        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(FREE_MIDS_HEADER_VALUE);
         boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
 
         assertTrue(hasPermission);
 
         verify(request).getHeader(ERIC_AUTHORISED_ROLES);
-        verify(stringHelper).asSet("\\s+", headerValue);
     }
 
     @Test
@@ -53,7 +49,6 @@ class EricAuthoriserTest {
     void shouldReturnFalseForInvalidPermission() {
         final String headerValue = "non-admin";
         when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(headerValue);
-        when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of("non-admin"));
         boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
 
         assertFalse(hasPermission);
@@ -73,7 +68,6 @@ class EricAuthoriserTest {
     void shouldReturnTrueForMultipleWithValidMIDSPermission() {
         String headerValue = FREE_MIDS_HEADER_VALUE + " " + FREE_CERT_DOCS_HEADER_VALUE;
         when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(headerValue);
-        when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of(FREE_MIDS_HEADER_VALUE,FREE_CERT_DOCS_HEADER_VALUE));
         boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
 
         assertTrue(hasPermission);

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
@@ -21,6 +21,8 @@ class EricAuthoriserTest {
 
     private static final String FREE_MIDS_PERMISSION= "/admin/free-mids";
 
+    private static final String FREE_CERT_DOCS_HEADER_VALUE= "/admin/free-cert-docs";
+
     private static final String FREE_MIDS_HEADER_VALUE= "/admin/free-mids";
 
     @Mock
@@ -40,7 +42,7 @@ class EricAuthoriserTest {
         when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of("/admin/free-mids"));
         boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
 
-        assertTrue(hasPermission, "User should have permission");
+        assertTrue(hasPermission);
 
         verify(request).getHeader(ERIC_AUTHORISED_ROLES);
         verify(stringHelper).asSet("\\s+", headerValue);
@@ -54,15 +56,26 @@ class EricAuthoriserTest {
         when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of("non-admin"));
         boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
 
-        assertFalse(hasPermission, "User should not have permission");
+        assertFalse(hasPermission);
     }
 
     @Test
-    @DisplayName("Should return false when the header is null")
+    @DisplayName("Should return false when the ERIC header is null")
     void shouldReturnFalseWhenHeaderIsMissing() {
         when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(null);
         boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
-        
-        assertFalse(hasPermission, "User should not have permission when header is missing");
+
+        assertFalse(hasPermission);
+    }
+
+    @Test
+    @DisplayName("Should return True when there are multiple permissions in header including free MIDS ")
+    void shouldReturnTrueForMultipleWithValidMIDSPermission() {
+        String headerValue = FREE_MIDS_HEADER_VALUE + " " + FREE_CERT_DOCS_HEADER_VALUE;
+        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(headerValue);
+        when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of(FREE_MIDS_HEADER_VALUE,FREE_CERT_DOCS_HEADER_VALUE));
+        boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
+
+        assertTrue(hasPermission);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_AUTHORISED_ROLES;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.util.StringHelper;
+
+import java.util.Set;
+
+@ExtendWith(MockitoExtension.class)
+class EricAuthoriserTest {
+
+    private static final String FREE_MIDS_PERMISSION= "/admin/free-mids";
+
+    private static final String FREE_MIDS_HEADER_VALUE= "/admin/free-mids";
+
+    @Mock
+    private StringHelper stringHelper;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @InjectMocks
+    private EricAuthoriser authoriser;
+
+    @Test
+    @DisplayName("Should return true when permission is present in the header")
+    void shouldReturnTrueForValidPermission() {
+        final String headerValue = FREE_MIDS_HEADER_VALUE;
+        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(headerValue);
+        when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of("/admin/free-mids"));
+        boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
+
+        assertTrue(hasPermission, "User should have permission");
+
+        verify(request).getHeader(ERIC_AUTHORISED_ROLES);
+        verify(stringHelper).asSet("\\s+", headerValue);
+    }
+
+    @Test
+    @DisplayName("Should return false when free permission is not present in the header")
+    void shouldReturnFalseForInvalidPermission() {
+        final String headerValue = "non-admin";
+        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(headerValue);
+        when(stringHelper.asSet("\\s+", headerValue)).thenReturn(Set.of("non-admin"));
+        boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
+
+        assertFalse(hasPermission, "User should not have permission");
+    }
+
+    @Test
+    @DisplayName("Should return false when the header is null")
+    void shouldReturnFalseWhenHeaderIsMissing() {
+        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn(null);
+        boolean hasPermission = authoriser.hasPermission(FREE_MIDS_PERMISSION, request);
+        
+        assertFalse(hasPermission, "User should not have permission when header is missing");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/interceptor/EricAuthoriserTest.java
@@ -1,7 +1,9 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.ERIC_AUTHORISED_ROLES;
 
 

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
@@ -178,7 +178,3 @@ class MissingImageDeliveryCostCalculatorServiceTest {
         assertThat(result).isEqualToComparingFieldByFieldRecursively(DISCOUNT_ADJUSTED_ITEM_COST_EXPECTED_CALCULATION);
     }
 }
-
-
-
-

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
@@ -18,7 +18,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.model.ProductType.MISSING_IMAGE_DELIVERY_ACCOUNTS;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.*;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.CALCULATED_COST;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.CALCULATED_COST_AFTER_DISCOUNT;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.DISCOUNT_APPLIED;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.DISCOUNT_APPLIED_WHEN_ELIGIBLE;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.MISSING_IMAGE_DELIVERY_ITEM_COST;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.MISSING_IMAGE_DELIVERY_ITEM_COST_STRING;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.POSTAGE_COST;
 
 /**
  * Unit tests the {@link MissingImageDeliveryCostCalculatorService} class.

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
@@ -18,11 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.model.ProductType.MISSING_IMAGE_DELIVERY_ACCOUNTS;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.CALCULATED_COST;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.DISCOUNT_APPLIED;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.MISSING_IMAGE_DELIVERY_ITEM_COST;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.MISSING_IMAGE_DELIVERY_ITEM_COST_STRING;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.POSTAGE_COST;
+import static uk.gov.companieshouse.missingimagedelivery.orders.api.util.TestConstants.*;
 
 /**
  * Unit tests the {@link MissingImageDeliveryCostCalculatorService} class.
@@ -37,25 +33,31 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     private static final String ADJUSTED_ITEM_COST_CALCULATED_COST = "5";
     private static final String ADJUSTED_ITEM_COST_TOTAL_ITEM_COST = "5";
 
+    private static final int BASIC_COST_DISCOUNT = 0;
+    private static final String DISCOUNT_ITEM_COST_STRING = "0";
+
     private static final int MVP_QUANTITY = 1;
     private static final int POST_MVP_QUANTITY = 5;
     private static final int INVALID_QUANTITY = 0;
+
+    private static final boolean USER_ELIGIBLE_FREE_CERTIFICATES = true;
+    private static final boolean USER_NOT_ELIGIBLE_FREE_CERTIFICATES = false;
 
     private static final ProductType ACCOUNTS_PRODUCT_TYPE = MISSING_IMAGE_DELIVERY_ACCOUNTS;
 
     private static final ItemCostCalculation MVP_EXPECTED_CALCULATION = new ItemCostCalculation(
             singletonList(new ItemCosts(DISCOUNT_APPLIED,
-                                        MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
-                                        CALCULATED_COST,
-                                        MISSING_IMAGE_DELIVERY_ACCOUNTS)),
+                    MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
+                    CALCULATED_COST,
+                    MISSING_IMAGE_DELIVERY_ACCOUNTS)),
             POSTAGE_COST,
             MVP_TOTAL_ITEM_COST);
 
     private static final ItemCostCalculation POST_MVP_EXPECTED_CALCULATION = new ItemCostCalculation(
             singletonList(new ItemCosts(DISCOUNT_APPLIED,
-                                        MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
-                                        CALCULATED_COST,
-                                        MISSING_IMAGE_DELIVERY_ACCOUNTS)),
+                    MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
+                    CALCULATED_COST,
+                    MISSING_IMAGE_DELIVERY_ACCOUNTS)),
             POSTAGE_COST,
             POST_MVP_TOTAL_ITEM_COST);
 
@@ -67,6 +69,15 @@ class MissingImageDeliveryCostCalculatorServiceTest {
             POSTAGE_COST,
             ADJUSTED_ITEM_COST_TOTAL_ITEM_COST);
 
+    private static final ItemCostCalculation FULL_DISCOUNT_EXPECTED_CALCULATION = new ItemCostCalculation(
+            singletonList(new ItemCosts(
+                    DISCOUNT_APPLIED, // Full discount amount, or you may use "0" depending on the logic
+                    DISCOUNT_ITEM_COST_STRING,
+                    "0",  // Should be "0" indicating the item cost after discount
+                    ACCOUNTS_PRODUCT_TYPE)),
+            POSTAGE_COST,  // Assuming no postage cost with full discount
+            FULL_DISCOUNT_EXPECTED_COST);
+
     @InjectMocks
     private MissingImageDeliveryCostCalculatorService serviceUnderTest;
 
@@ -77,7 +88,7 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     @DisplayName("calculateCosts produces expected results for MVP quantity")
     void calculateCostsProducesExpectedResultsForMvpQuantity() {
         when(costs.getMissingImageDeliveryItemCost()).thenReturn(MISSING_IMAGE_DELIVERY_ITEM_COST);
-        assertThat(serviceUnderTest.calculateCosts(MVP_QUANTITY, ACCOUNTS_PRODUCT_TYPE)).
+        assertThat(serviceUnderTest.calculateCosts(MVP_QUANTITY, ACCOUNTS_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES)).
                 isEqualToComparingFieldByFieldRecursively(MVP_EXPECTED_CALCULATION);
     }
 
@@ -85,7 +96,7 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     @DisplayName("calculateCosts produces expected results for a post MVP quantity")
     void calculateCostsProducesExpectedResultsForPostMvpQuantity() {
         when(costs.getMissingImageDeliveryItemCost()).thenReturn(MISSING_IMAGE_DELIVERY_ITEM_COST);
-        assertThat(serviceUnderTest.calculateCosts(POST_MVP_QUANTITY, ACCOUNTS_PRODUCT_TYPE))
+        assertThat(serviceUnderTest.calculateCosts(POST_MVP_QUANTITY, ACCOUNTS_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES))
                 .isEqualToComparingFieldByFieldRecursively(POST_MVP_EXPECTED_CALCULATION);
     }
 
@@ -94,7 +105,7 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     void incorrectQuantityTriggersIllegalArgumentException() {
         final IllegalArgumentException exception =
                 Assertions.assertThrows(IllegalArgumentException.class,
-                        () -> serviceUnderTest.calculateCosts(INVALID_QUANTITY, ACCOUNTS_PRODUCT_TYPE));
+                        () -> serviceUnderTest.calculateCosts(INVALID_QUANTITY, ACCOUNTS_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES));
         MatcherAssert.assertThat(exception.getMessage(), is("quantity must be greater than or equal to 1!"));
     }
 
@@ -102,8 +113,37 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     @DisplayName("Calculated cost should be the item cost")
     void calculatedCostIsItemCost() {
         when(costs.getMissingImageDeliveryItemCost()).thenReturn(ADJUSTED_MISSING_IMAGE_DELIVERY_ITEM_COST);
-        assertThat(serviceUnderTest.calculateCosts(MVP_QUANTITY, ACCOUNTS_PRODUCT_TYPE)).
+        assertThat(serviceUnderTest.calculateCosts(MVP_QUANTITY, ACCOUNTS_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES)).
                 isEqualToComparingFieldByFieldRecursively(ADJUSTED_ITEM_COST_EXPECTED_CALCULATION);
     }
 
+
+    @Test
+    @DisplayName("Calculated cost should be 0 when user is eligible for free certificates")
+    void calculatedCostIs0WithDiscount() {
+        when(costs.getMissingImageDeliveryItemCost()).thenReturn(BASIC_COST_DISCOUNT);
+        ItemCostCalculation result = serviceUnderTest.calculateCosts(
+                MVP_QUANTITY,
+                ACCOUNTS_PRODUCT_TYPE,
+                USER_ELIGIBLE_FREE_CERTIFICATES
+        );
+        assertThat(result).isEqualToComparingFieldByFieldRecursively(FULL_DISCOUNT_EXPECTED_CALCULATION);
+    }
+
+
+    @DisplayName("calculateCosts produces expected results for a post-MVP quantity with full discount")
+    @Test
+    void calculateCostsProducesExpectedResultsForPostMvpQuantityWithFullDiscount() {
+        when(costs.getMissingImageDeliveryItemCost()).thenReturn(BASIC_COST_DISCOUNT);
+        ItemCostCalculation result = serviceUnderTest.calculateCosts(
+                POST_MVP_QUANTITY,
+                ACCOUNTS_PRODUCT_TYPE,
+                USER_ELIGIBLE_FREE_CERTIFICATES
+        );
+        assertThat(result).isEqualToComparingFieldByFieldRecursively(FULL_DISCOUNT_EXPECTED_CALCULATION);
+    }
 }
+
+
+
+

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryCostCalculatorServiceTest.java
@@ -33,8 +33,8 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     private static final String ADJUSTED_ITEM_COST_CALCULATED_COST = "5";
     private static final String ADJUSTED_ITEM_COST_TOTAL_ITEM_COST = "5";
 
-    private static final int BASIC_COST_DISCOUNT = 0;
-    private static final String DISCOUNT_ITEM_COST_STRING = "0";
+    private static final String ADJUSTED_DISCOUNT_APPLIED_WHEN_ELIGIBLE = "5";
+    private static final String TOTAL_COST_AFTER_DISCOUNT = "0";
 
     private static final int MVP_QUANTITY = 1;
     private static final int POST_MVP_QUANTITY = 5;
@@ -71,12 +71,30 @@ class MissingImageDeliveryCostCalculatorServiceTest {
 
     private static final ItemCostCalculation FULL_DISCOUNT_EXPECTED_CALCULATION = new ItemCostCalculation(
             singletonList(new ItemCosts(
-                    DISCOUNT_APPLIED, // Full discount amount, or you may use "0" depending on the logic
-                    DISCOUNT_ITEM_COST_STRING,
-                    "0",  // Should be "0" indicating the item cost after discount
+                    DISCOUNT_APPLIED_WHEN_ELIGIBLE,
+                    MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
+                    CALCULATED_COST_AFTER_DISCOUNT,
                     ACCOUNTS_PRODUCT_TYPE)),
-            POSTAGE_COST,  // Assuming no postage cost with full discount
-            FULL_DISCOUNT_EXPECTED_COST);
+            POSTAGE_COST,
+            TOTAL_COST_AFTER_DISCOUNT);
+
+    private static final ItemCostCalculation POST_MVP_DISCOUNT_EXPECTED_CALCULATION = new ItemCostCalculation(
+            singletonList(new ItemCosts(
+                    DISCOUNT_APPLIED_WHEN_ELIGIBLE,
+                    MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
+                    CALCULATED_COST_AFTER_DISCOUNT,
+                    ACCOUNTS_PRODUCT_TYPE)),
+            POSTAGE_COST,
+            TOTAL_COST_AFTER_DISCOUNT);
+
+    private static final ItemCostCalculation DISCOUNT_ADJUSTED_ITEM_COST_EXPECTED_CALCULATION = new ItemCostCalculation(
+            singletonList(new ItemCosts(
+                    ADJUSTED_DISCOUNT_APPLIED_WHEN_ELIGIBLE,
+                    ADJUSTED_MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
+                    CALCULATED_COST_AFTER_DISCOUNT,
+                    ACCOUNTS_PRODUCT_TYPE)),
+            POSTAGE_COST,
+            TOTAL_COST_AFTER_DISCOUNT);
 
     @InjectMocks
     private MissingImageDeliveryCostCalculatorService serviceUnderTest;
@@ -119,9 +137,9 @@ class MissingImageDeliveryCostCalculatorServiceTest {
 
 
     @Test
-    @DisplayName("Calculated cost should be 0 when user is eligible for free certificates")
-    void calculatedCostIs0WithDiscount() {
-        when(costs.getMissingImageDeliveryItemCost()).thenReturn(BASIC_COST_DISCOUNT);
+    @DisplayName("Calculate Costs should be 0 when user is eligible for free certificates")
+    void calculatedCostIs0WithFullDiscount() {
+        when(costs.getMissingImageDeliveryItemCost()).thenReturn(MISSING_IMAGE_DELIVERY_ITEM_COST);
         ItemCostCalculation result = serviceUnderTest.calculateCosts(
                 MVP_QUANTITY,
                 ACCOUNTS_PRODUCT_TYPE,
@@ -131,16 +149,33 @@ class MissingImageDeliveryCostCalculatorServiceTest {
     }
 
 
-    @DisplayName("calculateCosts produces expected results for a post-MVP quantity with full discount")
+    @DisplayName("Calculate costs produces expected results for a post-MVP quantity with full discount")
     @Test
-    void calculateCostsProducesExpectedResultsForPostMvpQuantityWithFullDiscount() {
-        when(costs.getMissingImageDeliveryItemCost()).thenReturn(BASIC_COST_DISCOUNT);
+    void calculateCostsIs0ForPostMvpQuantityWithFullDiscount() {
+        when(costs.getMissingImageDeliveryItemCost()).thenReturn(MISSING_IMAGE_DELIVERY_ITEM_COST);
         ItemCostCalculation result = serviceUnderTest.calculateCosts(
                 POST_MVP_QUANTITY,
                 ACCOUNTS_PRODUCT_TYPE,
                 USER_ELIGIBLE_FREE_CERTIFICATES
         );
-        assertThat(result).isEqualToComparingFieldByFieldRecursively(FULL_DISCOUNT_EXPECTED_CALCULATION);
+        assertThat(result).isEqualToComparingFieldByFieldRecursively(POST_MVP_DISCOUNT_EXPECTED_CALCULATION);
+    }
+
+    @DisplayName("Calculated cost should be the item cost even when discount is applied")
+    @Test
+    void calculatedCostIsItemCostWithDiscount() {
+        // Mock the costs method to return the adjusted book delivery item cost
+        when(costs.getMissingImageDeliveryItemCost()).thenReturn(ADJUSTED_MISSING_IMAGE_DELIVERY_ITEM_COST);
+
+        // Call the method under test
+        ItemCostCalculation result = serviceUnderTest.calculateCosts(
+                POST_MVP_QUANTITY,
+                ACCOUNTS_PRODUCT_TYPE,
+                USER_ELIGIBLE_FREE_CERTIFICATES
+        );
+
+        // Validate the entire ItemCostCalculation object against the expected value
+        assertThat(result).isEqualToComparingFieldByFieldRecursively(DISCOUNT_ADJUSTED_ITEM_COST_EXPECTED_CALCULATION);
     }
 }
 

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
@@ -51,7 +51,6 @@ public class MissingImageDeliveryItemServiceTest {
 
     public static final String FILING_HISTORY_CATEGORY = "resolution";
     private static final ProductType MISC_PRODUCT_TYPE = MISSING_IMAGE_DELIVERY_MISC;
-    private static final boolean USER_ELIGIBLE_FREE_CERTIFICATES = true;
     private static final boolean USER_NOT_ELIGIBLE_FREE_CERTIFICATES = false;
 
     private static final ItemCosts ITEM_COSTS = new ItemCosts(DISCOUNT_APPLIED, MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
@@ -130,57 +129,4 @@ public class MissingImageDeliveryItemServiceTest {
         assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryBarcode(), is(FILING_HISTORY_BARCODE));
         verify(repository).save(missingImageDeliveryItem);
     }
-
-
-    @Test
-    @DisplayName("createMissingImageDeliveryItem creates and saves item with id, timestamps, etag and links, returns item with costs and item options")
-    void createMissingImageDeliveryItemHasDiscountForAdmin() {
-
-        // Given
-        when(idGeneratorService.autoGenerateId()).thenReturn(ID);
-        final MissingImageDeliveryItemOptions midItemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
-                FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE,
-                FILING_HISTORY_CATEGORY, FILING_HISTORY_BARCODE);
-        when(costCalculatorService.calculateCosts(QUANTITY, MISC_PRODUCT_TYPE, USER_ELIGIBLE_FREE_CERTIFICATES)).thenReturn(CALCULATION);
-        MissingImageDeliveryItemData missingImageDeliveryItemData = new MissingImageDeliveryItemData();
-        missingImageDeliveryItemData.setCompanyNumber(COMPANY_NUMBER);
-        MissingImageDeliveryItem missingImageDeliveryItem = new MissingImageDeliveryItem();
-        missingImageDeliveryItem.setData(missingImageDeliveryItemData);
-        missingImageDeliveryItem.setQuantity(QUANTITY);
-        missingImageDeliveryItem.setKind(KIND);
-        missingImageDeliveryItem.setItemOptions(midItemOptions);
-
-        when(repository.save(missingImageDeliveryItem)).thenReturn(missingImageDeliveryItem);
-
-        final LocalDateTime intervalStart = LocalDateTime.now();
-
-        // When
-        missingImageDeliveryItem = serviceUnderTest.createMissingImageDeliveryItem(missingImageDeliveryItem, USER_ELIGIBLE_FREE_CERTIFICATES);
-
-        // Then
-        final LocalDateTime intervalEnd = LocalDateTime.now();
-
-        verifyCreationTimestampsWithinExecutionInterval(missingImageDeliveryItem, intervalStart, intervalEnd);
-        assertThat(missingImageDeliveryItem.getId(), is(ID));
-        verify(etagGenerator).generateEtag();
-        verify(linksGenerator).generateLinks(ID);
-        assertThat(missingImageDeliveryItem.getId(), is(ID));
-        verify(costCalculatorService).calculateCosts(QUANTITY, MISC_PRODUCT_TYPE, USER_ELIGIBLE_FREE_CERTIFICATES);
-        verify(descriptionProviderService).getDescription(COMPANY_NUMBER);
-        assertThat(missingImageDeliveryItem.getItemCosts(), is(singletonList(ITEM_COSTS)));
-        assertThat(missingImageDeliveryItem.getPostageCost(), is(POSTAGE_COST));
-        assertThat(missingImageDeliveryItem.getKind(), is(KIND));
-        assertThat(missingImageDeliveryItem.getTotalItemCost(), is(TestConstants.TOTAL_ITEM_COST));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryDate(), is(FILING_HISTORY_DATE));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryDescription(),
-                is(FILING_HISTORY_DESCRIPTION));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryDescriptionValues(),
-                is(FILING_HISTORY_DESCRIPTION_VALUES));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryId(), is(FILING_HISTORY_ID));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryType(), is(FILING_HISTORY_TYPE));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY));
-        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryBarcode(), is(FILING_HISTORY_BARCODE));
-        verify(repository).save(missingImageDeliveryItem);
-    }
-
 }

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
@@ -51,6 +51,8 @@ public class MissingImageDeliveryItemServiceTest {
 
     public static final String FILING_HISTORY_CATEGORY = "resolution";
     private static final ProductType MISC_PRODUCT_TYPE = MISSING_IMAGE_DELIVERY_MISC;
+    private static final boolean USER_ELIGIBLE_FREE_CERTIFICATES = true;
+    private static final boolean USER_NOT_ELIGIBLE_FREE_CERTIFICATES = false;
 
     private static final ItemCosts ITEM_COSTS = new ItemCosts(DISCOUNT_APPLIED, MISSING_IMAGE_DELIVERY_ITEM_COST_STRING,
             CALCULATED_COST, MISSING_IMAGE_DELIVERY_MISC);
@@ -87,7 +89,7 @@ public class MissingImageDeliveryItemServiceTest {
         final MissingImageDeliveryItemOptions midItemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
                 FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE,
                 FILING_HISTORY_CATEGORY, FILING_HISTORY_BARCODE);
-        when(costCalculatorService.calculateCosts(QUANTITY, MISC_PRODUCT_TYPE)).thenReturn(CALCULATION);
+        when(costCalculatorService.calculateCosts(QUANTITY, MISC_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES)).thenReturn(CALCULATION);
         MissingImageDeliveryItemData missingImageDeliveryItemData = new MissingImageDeliveryItemData();
         missingImageDeliveryItemData.setCompanyNumber(COMPANY_NUMBER);
         MissingImageDeliveryItem missingImageDeliveryItem = new MissingImageDeliveryItem();
@@ -101,7 +103,7 @@ public class MissingImageDeliveryItemServiceTest {
         final LocalDateTime intervalStart = LocalDateTime.now();
 
         // When
-        missingImageDeliveryItem = serviceUnderTest.createMissingImageDeliveryItem(missingImageDeliveryItem);
+        missingImageDeliveryItem = serviceUnderTest.createMissingImageDeliveryItem(missingImageDeliveryItem, USER_NOT_ELIGIBLE_FREE_CERTIFICATES);
 
         // Then
         final LocalDateTime intervalEnd = LocalDateTime.now();
@@ -111,7 +113,59 @@ public class MissingImageDeliveryItemServiceTest {
         verify(etagGenerator).generateEtag();
         verify(linksGenerator).generateLinks(ID);
         assertThat(missingImageDeliveryItem.getId(), is(ID));
-        verify(costCalculatorService).calculateCosts(QUANTITY, MISC_PRODUCT_TYPE);
+        verify(costCalculatorService).calculateCosts(QUANTITY, MISC_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES);
+        verify(descriptionProviderService).getDescription(COMPANY_NUMBER);
+        assertThat(missingImageDeliveryItem.getItemCosts(), is(singletonList(ITEM_COSTS)));
+        assertThat(missingImageDeliveryItem.getPostageCost(), is(POSTAGE_COST));
+        assertThat(missingImageDeliveryItem.getKind(), is(KIND));
+        assertThat(missingImageDeliveryItem.getTotalItemCost(), is(TestConstants.TOTAL_ITEM_COST));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryDate(), is(FILING_HISTORY_DATE));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryDescription(),
+                is(FILING_HISTORY_DESCRIPTION));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryDescriptionValues(),
+                is(FILING_HISTORY_DESCRIPTION_VALUES));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryId(), is(FILING_HISTORY_ID));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryType(), is(FILING_HISTORY_TYPE));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY));
+        assertThat(missingImageDeliveryItem.getItemOptions().getFilingHistoryBarcode(), is(FILING_HISTORY_BARCODE));
+        verify(repository).save(missingImageDeliveryItem);
+    }
+
+
+    @Test
+    @DisplayName("createMissingImageDeliveryItem creates and saves item with id, timestamps, etag and links, returns item with costs and item options")
+    void createMissingImageDeliveryItemHasDiscountForAdmin() {
+
+        // Given
+        when(idGeneratorService.autoGenerateId()).thenReturn(ID);
+        final MissingImageDeliveryItemOptions midItemOptions = new MissingImageDeliveryItemOptions(FILING_HISTORY_DATE,
+                FILING_HISTORY_DESCRIPTION, FILING_HISTORY_DESCRIPTION_VALUES, FILING_HISTORY_ID, FILING_HISTORY_TYPE,
+                FILING_HISTORY_CATEGORY, FILING_HISTORY_BARCODE);
+        when(costCalculatorService.calculateCosts(QUANTITY, MISC_PRODUCT_TYPE, USER_ELIGIBLE_FREE_CERTIFICATES)).thenReturn(CALCULATION);
+        MissingImageDeliveryItemData missingImageDeliveryItemData = new MissingImageDeliveryItemData();
+        missingImageDeliveryItemData.setCompanyNumber(COMPANY_NUMBER);
+        MissingImageDeliveryItem missingImageDeliveryItem = new MissingImageDeliveryItem();
+        missingImageDeliveryItem.setData(missingImageDeliveryItemData);
+        missingImageDeliveryItem.setQuantity(QUANTITY);
+        missingImageDeliveryItem.setKind(KIND);
+        missingImageDeliveryItem.setItemOptions(midItemOptions);
+
+        when(repository.save(missingImageDeliveryItem)).thenReturn(missingImageDeliveryItem);
+
+        final LocalDateTime intervalStart = LocalDateTime.now();
+
+        // When
+        missingImageDeliveryItem = serviceUnderTest.createMissingImageDeliveryItem(missingImageDeliveryItem, USER_ELIGIBLE_FREE_CERTIFICATES);
+
+        // Then
+        final LocalDateTime intervalEnd = LocalDateTime.now();
+
+        verifyCreationTimestampsWithinExecutionInterval(missingImageDeliveryItem, intervalStart, intervalEnd);
+        assertThat(missingImageDeliveryItem.getId(), is(ID));
+        verify(etagGenerator).generateEtag();
+        verify(linksGenerator).generateLinks(ID);
+        assertThat(missingImageDeliveryItem.getId(), is(ID));
+        verify(costCalculatorService).calculateCosts(QUANTITY, MISC_PRODUCT_TYPE, USER_ELIGIBLE_FREE_CERTIFICATES);
         verify(descriptionProviderService).getDescription(COMPANY_NUMBER);
         assertThat(missingImageDeliveryItem.getItemCosts(), is(singletonList(ITEM_COSTS)));
         assertThat(missingImageDeliveryItem.getPostageCost(), is(POSTAGE_COST));

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/StringHelperTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/StringHelperTest.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.missingimagedelivery.orders.api.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+class StringHelperTest {
+
+    private static final String FREE_CERTS= "/admin/free-certs";
+    private static final String FREE_MIDS= "/admin/free-mids";
+    private static final String FREE_CERT_DOCS= "/admin/free-cert-docs";
+    private static final String EMPTY_STRING = "";
+    private static final String NULL_STRING = null;
+
+
+    private final StringHelper stringHelper = new StringHelper();
+
+
+    static Stream<Arguments> provideParamArgsForAsSetTests() {
+        return Stream.of(
+                // Checking comma as a delimeter
+                Arguments.of(FREE_CERTS + "," + FREE_MIDS + "," + FREE_CERT_DOCS, ",", Set.of(FREE_CERTS, FREE_MIDS, FREE_CERT_DOCS)),
+                Arguments.of(EMPTY_STRING, ",", Set.of()),
+                Arguments.of(NULL_STRING, ",", Set.of()),
+                // Checking parsing works with whitespace as delimeter
+                Arguments.of(" " + FREE_CERTS + " " + FREE_MIDS + " " + FREE_CERT_DOCS + " ", "\\s+", Set.of(FREE_CERTS, FREE_MIDS, FREE_CERT_DOCS))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParamArgsForAsSetTests")
+    @DisplayName("Should return a set with values split by a specified delimiter and handles null/empty values ")
+    void asSetSplitsAndHandlesEmptyValues(String input, String delimiter, Set<String> expectedSet) {
+        Set<String> result = stringHelper.asSet(delimiter, input);
+        Assertions.assertEquals(expectedSet, result);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
@@ -19,6 +19,7 @@ public class TestConstants {
     public static final String MISSING_IMAGE_DELIVERY_ITEM_COST_STRING = "3";
     public static final String POSTAGE_COST = "0";
     public static final String CALCULATED_COST = "3";
+    public static final String FULL_DISCOUNT_EXPECTED_COST = "0";
     public static final String TOTAL_ITEM_COST = "3";
 
 }

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
@@ -15,11 +15,12 @@ public class TestConstants {
     public static final String FILING_HISTORY_TYPE_CH01 = "CH01";
     public static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";
     public static final String DISCOUNT_APPLIED = "0";
+    public static final String DISCOUNT_APPLIED_WHEN_ELIGIBLE = "3";
     public static final int    MISSING_IMAGE_DELIVERY_ITEM_COST = 3;
     public static final String MISSING_IMAGE_DELIVERY_ITEM_COST_STRING = "3";
     public static final String POSTAGE_COST = "0";
     public static final String CALCULATED_COST = "3";
-    public static final String FULL_DISCOUNT_EXPECTED_COST = "0";
+    public static final String CALCULATED_COST_AFTER_DISCOUNT = "0";
     public static final String TOTAL_ITEM_COST = "3";
 
 }

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/util/TestConstants.java
@@ -10,6 +10,7 @@ public class TestConstants {
     public static final String ERIC_IDENTITY_TYPE_HEADER_NAME = "ERIC-Identity-Type";
     public static final String ERIC_IDENTITY_TYPE_API_KEY_VALUE = "key";
     public static final String MISSING_IMAGE_DELIVERY_URL = "/orderable/missing-image-deliveries";
+    public static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
     public static final ApiErrorResponsePayload FILING_NOT_FOUND =
         new ApiErrorResponsePayload(singletonList(new Error("ch:service", "filing-history-item-not-found")));
     public static final String FILING_HISTORY_TYPE_CH01 = "CH01";


### PR DESCRIPTION
Resolves [BI-12446](https://companieshouse.atlassian.net/browse/BI-12446)

- Adding changes to CostCalculator, MIDController/Service  as well as new helper classes EricAuthoriser and StringHelper to implement logic, allowing users who are logged in with the correct permission (free-mids) to full discount giving them free orders. 
- Adding Unit tests to cover new logic where necessary. 

<img width="984" alt="Screenshot 2024-07-31 at 08 13 31" src="https://github.com/user-attachments/assets/29558fef-dc49-437c-a08a-5d67e4030864">



[BI-12446]: https://companieshouse.atlassian.net/browse/BI-12446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ