### PR TITLE
Feature/BI-12446 free item calculation for admin get endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemController.java
@@ -29,13 +29,11 @@ import java.util.Optional;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
-import uk.gov.companieshouse.logging.Logger;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.REQUEST_ID_HEADER_NAME;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.USER_ID_LOG_KEY;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.COMPANY_NUMBER_LOG_KEY;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.MISSING_IMAGE_DELIVERY_ID_LOG_KEY;
 import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.STATUS_LOG_KEY;
-import static uk.gov.companieshouse.missingimagedelivery.orders.api.logging.LoggingUtils.getLogger;
 
 
 @RestController

--- a/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemService.java
+++ b/src/main/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemService.java
@@ -74,7 +74,7 @@ public class MissingImageDeliveryItemService {
                                   final boolean userGetsFreeCertificates) {
         MissingImageDeliveryItemOptions itemOptions = item.getItemOptions();
         String category = itemOptions.getFilingHistoryCategory();
-        ProductType productType = FilingHistoryCategory.enumValueOf(category).getProductType();
+        var productType = FilingHistoryCategory.enumValueOf(category).getProductType();
         final ItemCostCalculation costs = calculator.calculateCosts(item.getQuantity(), productType, userGetsFreeCertificates );
         item.setItemCosts(costs.getItemCosts());
         item.setPostageCost(costs.getPostageCost());

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerIntegrationTest.java
@@ -245,6 +245,7 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
     void getMissingImageDeliveryItemSuccessfully() throws Exception {
         final MissingImageDeliveryItem item = newMissingImageDeliveryItem();
         repository.save(item);
+        when(calculatorService.calculateCosts(QUANTITY_1, ACCOUNTS_PRODUCT_TYPE, USER_NOT_ELIGIBLE_FREE_CERTIFICATES)).thenReturn(CALCULATION);
 
         final MissingImageDeliveryItemResponseDTO expectedItem = new MissingImageDeliveryItemResponseDTO();
         expectedItem.setCompanyNumber(item.getCompanyNumber());
@@ -258,6 +259,9 @@ class MissingImageDeliveryItemControllerIntegrationTest extends AbstractMongoCon
         expectedItem.setItemOptions(item.getItemOptions());
         expectedItem.setPostalDelivery(item.isPostalDelivery());
         expectedItem.setKind(item.getKind());
+        expectedItem.setItemCosts(CALCULATION.getItemCosts());
+        expectedItem.setPostageCost(CALCULATION.getPostageCost());
+        expectedItem.setTotalItemCost(CALCULATION.getTotalItemCost());
 
         // When and then
         mockMvc.perform(get(MISSING_IMAGE_DELIVERY_URL + "/" + item.getId())

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/controller/MissingImageDeliveryItemControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.missingimagedelivery.orders.api.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.dto.MissingImageDeliveryItemResponseDTO;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.EricAuthoriser;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.mapper.MissingImageDeliveryItemMapper;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItemData;
@@ -30,6 +32,12 @@ public class MissingImageDeliveryItemControllerTest {
     private MissingImageDeliveryItemController controllerUnderTest;
 
     @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private EricAuthoriser authoriser;
+
+    @Mock
     private MissingImageDeliveryItemService missingImageDeliveryItemService;
 
     @Mock
@@ -47,10 +55,10 @@ public class MissingImageDeliveryItemControllerTest {
     @Test
     @DisplayName("GET missing image delivery resource returns item")
     void getMissingImageDeliveryItemPresent() {
-        when(missingImageDeliveryItemService.getMissingImageDeliveryItemById(ID)).thenReturn(Optional.of(item));
+        when(missingImageDeliveryItemService.getMissingImageDeliveryItemWithCosts(ID, false)).thenReturn(Optional.of(item));
         when(item.getData()).thenReturn(data);
         when(mapper.missingImageDeliveryItemToMissingImageDeliveryItemResponseDTO(data)).thenReturn(dto);
-        ResponseEntity<Object> response = controllerUnderTest.getMissingImageDeliveryItem(ID, REQUEST_ID_VALUE);
+        ResponseEntity<Object> response = controllerUnderTest.getMissingImageDeliveryItem(ID, REQUEST_ID_VALUE, request);
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
         assertThat(response.getBody(), is(dto));
@@ -59,8 +67,8 @@ public class MissingImageDeliveryItemControllerTest {
     @Test
     @DisplayName("Get missing image delivery resource returns HTTP NOT FOUND")
     void getMissingImageDeliveryItemNotFound() {
-        when(missingImageDeliveryItemService.getMissingImageDeliveryItemById(ID)).thenReturn(Optional.empty());
-        ResponseEntity<Object> response = controllerUnderTest.getMissingImageDeliveryItem(ID, REQUEST_ID_VALUE);
+        when(missingImageDeliveryItemService.getMissingImageDeliveryItemWithCosts(ID, false)).thenReturn(Optional.empty());
+        ResponseEntity<Object> response = controllerUnderTest.getMissingImageDeliveryItem(ID, REQUEST_ID_VALUE, request);
 
         assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
     }

--- a/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/missingimagedelivery/orders/api/service/MissingImageDeliveryItemServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.missingimagedelivery.orders.api.interceptor.EricAuthoriser;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ItemCostCalculation;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.ItemCosts;
 import uk.gov.companieshouse.missingimagedelivery.orders.api.model.MissingImageDeliveryItem;
@@ -69,6 +70,9 @@ public class MissingImageDeliveryItemServiceTest {
 
     @Mock
     private IdGeneratorService idGeneratorService;
+
+    @Mock
+    EricAuthoriser authoriser;
 
     @Mock
     private MissingImageDeliveryItemRepository repository;


### PR DESCRIPTION
Resolves [BI-12446](https://companieshouse.atlassian.net/jira/software/c/projects/GCI/boards/453?selectedIssue=BI-12446)

Add in Eric Authoriser check in `GET` endpoint to ensure MIDs are calculated accurately when logging in as admin or non-admin user when in basket. 

[BI-12446]: https://companieshouse.atlassian.net/browse/BI-12446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ