### PR TITLE
add scaledown, target cpu scaling, and update modules

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.253"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.287"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -28,7 +28,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.253"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.287"
 
   # Environmental configuration
   environment             = var.environment

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -2,3 +2,8 @@ environment = "cidev"
 aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
+
+# scaling configs
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/phoenix1/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/phoenix1/vars
@@ -2,3 +2,8 @@ environment = "phoenix1"
 aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
+
+# scaling configs
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -79,7 +79,7 @@ variable "service_autoscale_enabled" {
 variable "service_autoscale_target_value_cpu" {
   type        = number
   description = "Target CPU percentage for the ECS Service to autoscale on"
-  default     = 50 # 100 disables autoscaling using CPU as a metric
+  default     = 80 # 100 disables autoscaling using CPU as a metric
 }
 
 variable "service_scaledown_schedule" {


### PR DESCRIPTION
Update modules to latest version, configure target cpu for scaling to 80% instead of 50%. Also added scale down and up. CPU and memory metrics look ok in aws for the different environments.